### PR TITLE
Changed LPOP to BLPOP in file redis_store.go

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,6 +36,7 @@ func NewConfig(configFilePath string) {
 		ConfigOption("redis_message_queue", "Incus_Queue")
 		ConfigOption("redis_activity_consumers", 8)
 		ConfigOption("redis_connection_pool_size", 20)
+		ConfigOption("redis_blpop_timeout", 10)
 	}
 
 	ConfigOption("tls_enabled", false)

--- a/config.yml
+++ b/config.yml
@@ -37,6 +37,9 @@ redis_activity_consumers: 8
 # Number of concurrent connections to Redis in the connection pool.
 redis_connection_pool_size: 20
 
+# Max number of seconds BLPOP waits before returning anyway. Must be a positive integer. 0 means wait indefinitely.
+redis_blpop_timeout: 10
+
 # ----- TLS Support -----
 
 # Bool; true if tls enabled, false otherwise.

--- a/redis_store.go
+++ b/redis_store.go
@@ -37,7 +37,7 @@ type RedisStore struct {
 	server                    string
 	port                      int
 	pool                      *redisPool
-	pollingFreq               time.Duration
+	pollingFreq               int
 	incomingRedisActivityCmds chan RedisCommand
 	redisPendingQueue         *RedisQueue
 }


### PR DESCRIPTION
I created a new pull request with BLPOP change in redis_store.go as requested yesterday. Timeout interval is now configurable in config.yml.
